### PR TITLE
Add emotion statistics screen with frequency analysis

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -6,6 +6,7 @@ import '../models/emotion.dart';
 import '../providers/emotion_provider.dart';
 import '../models/emotion_entry.dart';
 import 'emotion_selection_screen.dart';
+import 'statistics_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   const HomeScreen({super.key});
@@ -33,6 +34,19 @@ class _HomeScreenState extends State<HomeScreen> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Daily Pulse'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.bar_chart),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const StatisticsScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Consumer<EmotionProvider>(
         builder: (context, provider, child) {

--- a/lib/screens/statistics_screen.dart
+++ b/lib/screens/statistics_screen.dart
@@ -1,0 +1,140 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/emotion_provider.dart';
+import '../models/emotion.dart';
+
+class StatisticsScreen extends StatelessWidget {
+  const StatisticsScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Emotion Statistics'),
+      ),
+      body: Consumer<EmotionProvider>(
+        builder: (context, provider, child) {
+          if (provider.isLoading) {
+            return const Center(child: CircularProgressIndicator());
+          }
+
+          if (provider.entries.isEmpty) {
+            return const Center(
+              child: Text('No emotions recorded yet'),
+            );
+          }
+
+          // Group emotions by type
+          final emotionCounts = <String, int>{};
+          for (final entry in provider.entries) {
+            final emotion = predefinedEmotions.firstWhere(
+              (e) => e.id == entry.emotionId,
+              orElse: () => Emotion(
+                id: entry.emotionId,
+                name: entry.customEmotion ?? 'Unknown',
+                emoji: entry.customEmoji ?? '❓',
+                color: const Color(0xFF607D8B),
+              ),
+            );
+            emotionCounts[emotion.name] =
+                (emotionCounts[emotion.name] ?? 0) + 1;
+          }
+
+          // Sort emotions by frequency
+          final sortedEmotions = emotionCounts.entries.toList()
+            ..sort((a, b) => b.value.compareTo(a.value));
+
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Most Common Emotions',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 16),
+                      ...sortedEmotions.map((entry) {
+                        final emotion = predefinedEmotions.firstWhere(
+                          (e) => e.name == entry.key,
+                          orElse: () => Emotion(
+                            id: 'custom',
+                            name: entry.key,
+                            emoji: '❓',
+                            color: const Color(0xFF607D8B),
+                          ),
+                        );
+                        return Padding(
+                          padding: const EdgeInsets.only(bottom: 8),
+                          child: Row(
+                            children: [
+                              Text(
+                                emotion.emoji,
+                                style: const TextStyle(fontSize: 24),
+                              ),
+                              const SizedBox(width: 8),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(emotion.name),
+                                    LinearProgressIndicator(
+                                      value:
+                                          entry.value / provider.entries.length,
+                                      backgroundColor:
+                                          emotion.color.withOpacity(0.1),
+                                      valueColor: AlwaysStoppedAnimation<Color>(
+                                        emotion.color,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                              const SizedBox(width: 8),
+                              Text(
+                                '${entry.value}',
+                                style: Theme.of(context).textTheme.titleMedium,
+                              ),
+                            ],
+                          ),
+                        );
+                      }),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 16),
+              Card(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Summary',
+                        style: Theme.of(context).textTheme.titleLarge,
+                      ),
+                      const SizedBox(height: 16),
+                      Text(
+                        'Total entries: ${provider.entries.length}',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                      Text(
+                        'Unique emotions: ${emotionCounts.length}',
+                        style: Theme.of(context).textTheme.titleMedium,
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}


### PR DESCRIPTION
Just testing this pr

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Introduce a new "StatisticsScreen" to the app, which displays emotion statistics and frequency analysis of recorded emotions within the app's home screen.

### Why are these changes being made?

This change aims to enhance user experience by providing insightful data visualization that helps users understand their emotional patterns over time. By adding a dedicated statistics screen, users can easily access and interpret the frequency of their recorded emotions, leading to increased self-awareness and engagement with the application.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->